### PR TITLE
docs: add sidgaikwad example config (screenshot-to-clipboard bindings)

### DIFF
--- a/examples/sidgaikwad.json
+++ b/examples/sidgaikwad.json
@@ -1,0 +1,25 @@
+{
+  // caps lock → hyper when held, caps lock when tapped
+  "caps": { "t": "hyper", "a": "100 caps" },
+
+  // fn as a layer: tap fn alone = cmd+tab (app switcher)
+  "fn": {
+    "_self": { "t": "fn", "a": "cmd tab" },
+
+    // --- Screenshots straight to clipboard ---
+    "s": "ctrl cmd shift 4", // snip an area → clipboard
+    "shift s": "ctrl cmd shift 3", // whole screen → clipboard
+    "5": "cmd shift 5", // screenshot & screen-recording toolbar
+
+    // --- Vim-style arrows (home-row navigation) ---
+    "h": "left_arrow",
+    "j": "down_arrow",
+    "k": "up_arrow",
+    "l": "right_arrow",
+
+    // --- Handy extras ---
+    "d": "delete_forward", // forward delete
+    "e": "ctrl cmd spacebar", // emoji & symbols picker
+    "spacebar": "cmd spacebar" // Spotlight
+  }
+}


### PR DESCRIPTION
Adds `examples/sidgaikwad.json` — a personal `konfig` example that leans on the `fn` layer for common macOS actions, in the same spirit as `examples/nrjdalal.json`.

Highlights:
- **Screenshots straight to the clipboard** — `fn s` -> ctrl+cmd+shift+4 (snip an area), `fn shift s` -> ctrl+cmd+shift+3 (whole screen), `fn 5` -> cmd+shift+5 (screenshot toolbar)
- **Vim-style arrows** — `fn h/j/k/l`
- **Handy extras** — `fn d` forward-delete, `fn e` emoji picker, `fn spacebar` Spotlight

Generated and validated with the current CLI (`khc -i examples/sidgaikwad.json`) — output is valid Karabiner JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)