### PR TITLE
docs: add a shared macOS essentials example config

### DIFF
--- a/examples/macos-essentials.json
+++ b/examples/macos-essentials.json
@@ -1,0 +1,30 @@
+{
+  // caps lock → hyper when held, caps lock when tapped
+  "caps": { "t": "hyper", "a": "100 caps" },
+
+  // fn as a layer: tap fn alone = cmd+tab (app switcher)
+  "fn": {
+    "_self": { "t": "fn", "a": "cmd tab" },
+
+    // --- Screenshots straight to clipboard ---
+    "s": "ctrl cmd shift 4", // snip an area → clipboard
+    "shift s": "ctrl cmd shift 3", // whole screen → clipboard
+    "5": "cmd shift 5", // screenshot & screen-recording toolbar
+
+    // --- Vim-style arrows (home-row navigation) ---
+    "h": "left_arrow",
+    "j": "down_arrow",
+    "k": "up_arrow",
+    "l": "right_arrow",
+
+    // --- System ---
+    "spacebar": "cmd spacebar", // Spotlight
+    "e": "ctrl cmd spacebar", // emoji & symbols picker
+    "q": "ctrl cmd q", // lock screen
+    "d": "delete_forward", // forward delete
+
+    // --- Navigation (back / forward in browsers, Finder, etc.) ---
+    "open_bracket": "cmd open_bracket",
+    "close_bracket": "cmd close_bracket"
+  }
+}


### PR DESCRIPTION
Adds `examples/macos-essentials.json` — a generic, no-personal-links `konfig` example anyone can drop in and use, alongside `examples/nrjdalal.json`.

It uses the `fn` key as a layer:

- **Screenshots to clipboard** — `fn s` -> ctrl+cmd+shift+4 (snip area), `fn shift s` -> ctrl+cmd+shift+3 (full screen), `fn 5` -> cmd+shift+5 (toolbar)
- **Vim-style arrows** — `fn h/j/k/l`
- **Window & spaces** — `fn m` Mission Control, `fn n` App Exposé, `fn f` fullscreen, `` fn ` `` cycle app windows
- **System** — `fn spacebar` Spotlight, `fn e` emoji picker, `fn q` lock screen, `fn d` forward-delete
- **Navigation** — `fn [` / `fn ]` back / forward

Generated and validated with the current CLI — output is valid Karabiner JSON (19 rules).